### PR TITLE
Found some breaking changes since Hapi v19

### DIFF
--- a/hapi-16/extend-hapi-with-plugins/server.js
+++ b/hapi-16/extend-hapi-with-plugins/server.js
@@ -1,5 +1,5 @@
-var Hapi = require('hapi')
-var Good = require('good')
+var Hapi = require('@hapi/hapi')
+var Good = require('@hapi/good')
 
 // create new server instance
 var server = new Hapi.Server()
@@ -14,14 +14,14 @@ server.connection({
 server.route({
   method: 'GET',
   path: '/',
-  handler: function (request, reply) {
-    reply('Hello Future Studio!')
+  handler: function (request, h) {
+    return 'Hello Future Studio!'
   }
 })
 
 // register plugins to server instance
 server.register({
-  register: Good,
+  plugin: Good,
   options: {
     ops: {
       interval: 10000
@@ -29,12 +29,12 @@ server.register({
     reporters: {
       console: [
         {
-          module: 'good-squeeze',
+          module: '@hapi/good-squeeze',
           name: 'Squeeze',
-          args: [ { log: '*', response: '*', request: '*' } ]
+          args: [ { log: '*', response: '*', request: '*', ops: '*' } ]
         },
         {
-          module: 'good-console'
+          module: '@hapi/good-console'
         },
         'stdout'
       ]


### PR DESCRIPTION
Coming from this Future Studio tutorial for Hapi ( https://futurestud.io/tutorials/hapi-extend-your-server-functionality-with-plugins), the snippets failed to run so I did some digging and wanna contribute a bit:
- Dependency names have prefix '@hapi/'
- Registering plugins requires key 'plugin' instead of 'register'
- Good options seem self-contradicting? i.e. ops is set at interval 1000 but reporters exclude the ops arg